### PR TITLE
Slight change to how class autoloading works

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -580,9 +580,14 @@
     }
 
     // Class Autloader
-    function __autoload($class_name)
+    spl_autoload_register('framework_autoload');
+
+    function framework_autoload($class_name)
     {
-        require DOC_ROOT . '/includes/class.' . strtolower($class_name) . '.php';
+        $file = DOC_ROOT . '/includes/class.' . strtolower($class_name) . '.php';
+        echo $file;
+        if (file_exists($file))
+            require $file;
     }
 
     // Returns a file's mimetype based on its extension


### PR DESCRIPTION
Make's class autoloader work nice with other libraries/frameworks which attempt to autoload. (As long as the use spl_autoload_register.
