### PR TITLE
Auth::createNewUser error due to null level field

### DIFF
--- a/includes/class.auth.php
+++ b/includes/class.auth.php
@@ -190,7 +190,7 @@
             }
         }
 
-        public static function createNewUser($username, $password = null)
+        public static function createNewUser($username, $password = null, $level = 'user')
         {
             if(is_null($password))
                 $password = Auth::generateStrongPassword();
@@ -200,6 +200,7 @@
             $u->username = $username;
             $u->nid = self::newNid();
             $u->password = self::hashedPassword($password);
+	    $u->level = $level;
             $u->insert();
             return $u;
         }

--- a/includes/master.inc.php
+++ b/includes/master.inc.php
@@ -34,4 +34,4 @@
     $Error = SPFError::getError();
 
     // If you need to bootstrap a first user into the database, you can run this line once
-    // Auth::createNewUser('username', 'password');
+    // Auth::createNewUser('username', 'password', 'level');


### PR DESCRIPTION
Line 36 and 37 of master.inc.php is as follows:
```
// If you need to bootstrap a first user into the database, you can run this line once
// Auth::createNewUser('username', 'password');
```

However, since the "level" field of the users table is set to NOT NULL, this results in the following error:
```
Database Error:
Column 'level' cannot be null
```

Fixing this by simply supplying the appropriate level to Auth::createNewUser was not possible without modifying the createNewUser function because that function did not accept any parameters other than username and password.