### PR TITLE
Index for nid in users table

### DIFF
--- a/mysql.sql
+++ b/mysql.sql
@@ -21,5 +21,6 @@ CREATE TABLE `users` (
   `level` enum('user','admin') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'user',
   `twostep` varchar(6) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `username` (`username`)
+  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `nid` (`nid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
Considering that class.auth.php, line 306, does a SELECT ... WHERE nid = ... it could be wise to add an unique index for "nid". Query response time very noticeable when you start having +100 users or even less...